### PR TITLE
Send messages to user directly

### DIFF
--- a/owncast-demobot/httpcontroller.go
+++ b/owncast-demobot/httpcontroller.go
@@ -45,10 +45,10 @@ func UserJoin(w http.ResponseWriter, r *http.Request) {
 		log.Print(err)
 	}
 
-	go SendSystemMessage(GetUserJoinMessage(event.EventData.User.DisplayName), 1)
+	go SendSystemMessageToClient(event.EventData.ClientId, GetUserJoinMessage(event.EventData.User.DisplayName), 1)
 	if IsNewUser(event.EventData.User.Id) {
-		go SendSystemMessage(GetBotIntroductionMessage(), 3)
-		go SendSystemMessage(GetNameChangeHint(event.EventData.User.DisplayName), 5)
+		go SendSystemMessageToClient(event.EventData.ClientId, GetBotIntroductionMessage(), 3)
+		go SendSystemMessageToClient(event.EventData.ClientId, GetNameChangeHint(event.EventData.User.DisplayName), 5)
 	}
 
 	AddKnownUser(event.EventData.User.Id)
@@ -63,7 +63,7 @@ func UserNameChange(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(event.EventData.User.PreviousNames) == 1 {
-		go SendSystemMessage(GetNamechangeMessage(event.EventData.User.DisplayName), 1)
+		go SendSystemMessageToClient(event.EventData.ClientId, GetNamechangeMessage(event.EventData.User.DisplayName), 1)
 	}
 }
 
@@ -77,14 +77,14 @@ func UserMessage(w http.ResponseWriter, r *http.Request) {
 
 	switch event.EventData.Body { /* bot commands*/
 	case "!bot":
-		go SendSystemMessage(GetBotHelpText(), 0)
+		go SendSystemMessageToClient(event.EventData.ClientId, GetBotHelpText(), 0)
 	case "!links":
-		go SendSystemMessage(GetFurtherResourcesMessage(), 0)
+		go SendSystemMessageToClient(event.EventData.ClientId, GetFurtherResourcesMessage(), 0)
 	}
 
 	if strings.Contains(event.EventData.Body, "?") || strings.Contains(event.EventData.Body, "is ") { // User-Question
-		go SendSystemMessage("Good question, but I can't answer it properly yet. I'm just a bot, remember? Here's the best I came up with:", 1)
-		go SendSystemMessage(GetFurtherResourcesMessage(), 2)
+		go SendSystemMessageToClient(event.EventData.ClientId, "Good question, but I can't answer it properly yet. I'm just a bot, remember? Here's the best I came up with:", 1)
+		go SendSystemMessageToClient(event.EventData.ClientId, GetFurtherResourcesMessage(), 2)
 	}
 }
 

--- a/owncast-demobot/httpmiddleware.go
+++ b/owncast-demobot/httpmiddleware.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -9,11 +11,11 @@ func RequireHttpPost(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			http.Error(w, "Unsupported Method", http.StatusMethodNotAllowed)
-			return;
+			return
 		}
 
 		next.ServeHTTP(w, r)
-	   }
+	}
 }
 
 func RequireJsonContentType(next http.HandlerFunc) http.HandlerFunc {
@@ -29,6 +31,9 @@ func RequireJsonContentType(next http.HandlerFunc) http.HandlerFunc {
 func LogRequest(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Tracing request for '%s' from '%s'", r.RequestURI, r.RemoteAddr)
+		body, _ := ioutil.ReadAll(r.Body)
+		log.Printf("Body %s", string(body))
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 		next.ServeHTTP(w, r)
-	   }
+	}
 }

--- a/owncast-demobot/owncastapiclient.go
+++ b/owncast-demobot/owncastapiclient.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -20,6 +21,25 @@ func SendSystemMessage(message string, sendDelay int) {
 	})
 	responseBody := bytes.NewBuffer(postBody)
 	req, _ := http.NewRequest("POST", getApiUrlFor("/api/integrations/chat/system"), responseBody)
+	req.Header.Add("Authorization", "Bearer "+DemoBotConfiguration.AccessToken)
+	req.Header.Add("ContentType", "application/json")
+
+	client := &http.Client{}
+	_, err := client.Do(req)
+	if err != nil {
+		log.Println("Error on response.\n[ERROR] -", err)
+	}
+}
+
+func SendSystemMessageToClient(clientId uint, message string, sendDelay int) {
+	time.Sleep(time.Duration(sendDelay) * time.Second)
+	var clientIdString string = strconv.FormatUint(uint64(clientId), 10)
+
+	postBody, _ := json.Marshal(map[string]string{
+		"body": message,
+	})
+	responseBody := bytes.NewBuffer(postBody)
+	req, _ := http.NewRequest("POST", getApiUrlFor("/api/integrations/chat/system/client/"+clientIdString), responseBody)
 	req.Header.Add("Authorization", "Bearer "+DemoBotConfiguration.AccessToken)
 	req.Header.Add("ContentType", "application/json")
 

--- a/owncast-demobot/webhookstypes.go
+++ b/owncast-demobot/webhookstypes.go
@@ -28,6 +28,7 @@ type User struct {
 type ChatMessage struct {
 	User      User      `json:"user,omitempty"`
 	Body      string    `json:"body,omitempty"`
+	ClientId  uint      `json:"clientId"`
 	RawBody   string    `json:"rawBody,omitempty"`
 	ID        string    `json:"id,omitempty"`
 	Visible   bool      `json:"visible"`
@@ -59,6 +60,7 @@ type NameChangeEvent struct {
 	Id        string    `json:"id"`
 	Timestamp time.Time `json:"timestamp"`
 	User      User      `json:"user"`
+	ClientId  uint      `json:"clientId"`
 }
 
 type NameChangeWebhookEvent struct {


### PR DESCRIPTION
Hey,

in this PR I've added support for the Demo-Bot of the newly exposed HTTP-API endpoint introduced in https://github.com/owncast/owncast/pull/1351 . The bot now sends more messages to clients directly, rather spamming the whole chat-history full with bot-output. 

I've also added more verbose logging of the body to the middleware (which is just easier for me to track the request bodies and hopefully also helps in the future to more quickly identify how webhook POSTs look like - just to keep the docs updated more easily without always hooking an interception proxy in between).

![image](https://user-images.githubusercontent.com/42910918/131025618-d3d24c0d-04d8-4d15-83f9-ed50daa82e7f.png)


BR,
Raffi